### PR TITLE
Unirest updated to 2.2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.0",
-        "mashape/unirest-php" : "dev-master"
+        "mashape/unirest-php" : "2.2.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/OAuth_io/HttpWrapper.php
+++ b/src/OAuth_io/HttpWrapper.php
@@ -1,10 +1,13 @@
 <?php
+
+use Unirest\Request as Request;
+
 namespace OAuth_io;
 
 class HttpWrapper {
     public function __create() {
     }
-    
+
     private function array_map_recursive($callback, $array) {
         foreach ($array as $key => $value) {
             if (is_object($array[$key])) {
@@ -15,10 +18,10 @@ class HttpWrapper {
         }
         return $array;
     }
-    
+
     public function make_request($options) {
         $injector = Injector::getInstance();
-        
+
         $url = $options['url'];
         $method = $options['method'];
         $headers = $options['headers'];
@@ -30,26 +33,9 @@ class HttpWrapper {
         }
         $url = str_replace('%2C', ',', $url);
 
-        \Unirest::verifyPeer($injector->ssl_verification);
-        if ($options['method'] == 'GET') {
-            $response = \Unirest::get($url, $headers);
-        }
-        
-        if ($options['method'] == 'POST') {
-            $response = \Unirest::post($url, $headers, $body);
-        }
-        
-        if ($options['method'] == 'PUT') {
-            $response = \Unirest::put($url, $headers, $body);
-        }
-        
-        if ($options['method'] == 'DELETE') {
-            $response = \Unirest::delete($url, $headers);
-        }
-        
-        if ($options['method'] == 'PATCH') {
-            $response = \Unirest::patch($url, $headers, $body);
-        }
+        Request::verifyPeer($injector->ssl_verification);
+
+        $response = Request::send($options['method'], $url, $headers);
 
         return $response;
     }


### PR DESCRIPTION
- set fixed package dependency at 2.2.1
- update unirest to use new namespaced signature
- utilize new `Request::send()` method to simplify code

*Note: I'm the maintainer of Unirest for PHP, figured i'd ensure the library is working in all dependents :)*